### PR TITLE
explicit batch size in readme

### DIFF
--- a/egs/spanish-numbers/README.md
+++ b/egs/spanish-numbers/README.md
@@ -38,7 +38,7 @@ tar -xvzf data/Spanish_Number_DB.tgz -C data/;
 ```bash
 ../../laia-train-ctc \
   --adversarial_weight 0.5 \
-  --batch_size "$batch_size" \
+  --batch_size 16 \
   --log_also_to_stderr info \
   --log_level info \
   --log_file laia.log \


### PR DESCRIPTION
Otherwise copy and paste leads to a complaint that the variable is not defined.