### PR TITLE
Prevent memory use on non-selected GPUs

### DIFF
--- a/egs/bentham/steps/train_lstm1d.sh
+++ b/egs/bentham/steps/train_lstm1d.sh
@@ -60,6 +60,9 @@ Options:
 source "$(pwd)/utils/parse_options.inc.sh" || exit 1;
 [ $# -ne 0 ] && echo "$help_message" >&2 && exit 1;
 
+export CUDA_VISIBLE_DEVICES=$((gpu-1))
+gpu=1
+
 # Check required files
 for f in  "data/lists/te_h$height.lst" \
 	  "data/lists/tr_h$height.lst" \

--- a/egs/iam/steps/decode_net.sh
+++ b/egs/iam/steps/decode_net.sh
@@ -33,6 +33,10 @@ Options:
 ";
 source "$(pwd)/utils/parse_options.inc.sh" || exit 1;
 [ $# -ne 1 ] && echo "$help_message" >&2 && exit 1;
+
+export CUDA_VISIBLE_DEVICES=$((gpu-1))
+gpu=1
+
 model="$1";
 model_name="$(basename "$1" .t7)";
 

--- a/egs/iam/steps/train_lstm1d.sh
+++ b/egs/iam/steps/train_lstm1d.sh
@@ -91,6 +91,9 @@ Options:
 source "$(pwd)/utils/parse_options.inc.sh" || exit 1;
 [ $# -ne 0 ] && echo "$help_message" >&2 && exit 1;
 
+export CUDA_VISIBLE_DEVICES=$((gpu-1))
+gpu=1
+
 for f in  "data/lists/lines/$partition/te_h$height.lst" \
 	  "data/lists/lines/$partition/tr_h$height.lst" \
 	  "data/lists/lines/$partition/va_h$height.lst" \

--- a/egs/iam/steps/train_lstm2d.sh
+++ b/egs/iam/steps/train_lstm2d.sh
@@ -35,6 +35,9 @@ Options:
 source "$(pwd)/utils/parse_options.inc.sh" || exit 1;
 [ $# -ne 0 ] && echo "$help_message" >&2 && exit 1;
 
+export CUDA_VISIBLE_DEVICES=$((gpu-1))
+gpu=1
+
 # Get "lines" or "sentences" from the full partition string (e.g. lines/aachen)
 ptype="${partition%%/*}";
 

--- a/egs/plantas/steps/train_lstm1d.sh
+++ b/egs/plantas/steps/train_lstm1d.sh
@@ -60,7 +60,10 @@ Options:
 source "$(pwd)/utils/parse_options.inc.sh" || exit 1;
 [ $# -ne 0 ] && echo "$help_message" >&2 && exit 1;
 
-# Check required files
+export CUDA_VISIBLE_DEVICES=$((gpu-1))
+gpu=1
+
+ #Check required files
 for f in "data/lists/tr_h$height.lst" \
 	 "data/lists/va_h$height.lst" \
 	 "data/lang/char/tr.txt" \

--- a/egs/rimes/steps/train_lstm1d.sh
+++ b/egs/rimes/steps/train_lstm1d.sh
@@ -44,6 +44,9 @@ Options:
 source "$(pwd)/utils/parse_options.inc.sh" || exit 1;
 [ $# -ne 0 ] && echo "$help_message" >&2 && exit 1;
 
+export CUDA_VISIBLE_DEVICES=$((gpu-1))
+gpu=1
+
 # Check required files
 for f in  "data/lists/te_h$height.lst" \
 	  "data/lists/tr_h$height.lst" \


### PR DESCRIPTION
Selecting a GPU via cutorch.setDevice() still results in some memory being used on other GPUs, so I updated the training shell scripts to restrict the GPU via the environment variable CUDA_VISIBLE_DEVICES (see, for example, https://stackoverflow.com/questions/33807398/torch-cuda-generates-two-processes-on-both-gpu-cores ).
